### PR TITLE
Update database.mdx

### DIFF
--- a/v2/pt/requirements/database.mdx
+++ b/v2/pt/requirements/database.mdx
@@ -19,7 +19,7 @@ A maneira mais fácil e rápida de configurar um banco de dados para a Evolution
 
 Para configurar o PostgreSQL via Docker, siga os passos abaixo:
 
-1. Baixe o arquivo `docker-compose.yaml` para o PostgreSQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/v2.0.0/Docker/postgres/docker-compose.yaml).
+1. Baixe o arquivo `docker-compose.yaml` para o PostgreSQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/main/Docker/postgres/docker-compose.yaml).
 2. Navegue até o diretório onde o arquivo foi baixado e execute o comando:
 
 ```bash


### PR DESCRIPTION
Fixing Postgres doc link

## Summary by Sourcery

Documentation:
- Update the PostgreSQL configuration documentation link to reference the main branch instead of a specific version tag