### PR TITLE
Correct findStatusMessage params

### DIFF
--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -4706,9 +4706,13 @@
                       }
                     }
                   },
-                  "limit": {
+                  "offset": {
                     "type": "integer",
                     "description": "Limit for the return"
+                  },
+                  "page": {
+                    "type": "integer",
+                    "description": "Page number of the returned results"
                   }
                 }
               }


### PR DESCRIPTION
The current docs shows a `limit` parameter that is not used in practice. It also lacks the parameters `offset` and `page` which are indeed used.

For more information, see [`findStatusMessage` at `src/api/services/channel.service.ts`](https://github.com/EvolutionAPI/evolution-api/blob/427c99499394d3894e4b065626323c45e91022e4/src/api/services/channel.service.ts#L658)

## Summary by Sourcery

Align the OpenAPI v2 spec for the findStatusMessage endpoint with its actual implementation by removing the unused 'limit' parameter and adding the missing 'offset' and 'page' parameters.

Documentation:
- Remove the unused 'limit' parameter from the findStatusMessage operation in openapi-v2.json
- Add the 'offset' and 'page' parameters to the findStatusMessage operation in openapi-v2.json