### PR TITLE
Feat: Add requirements using single file docker-compose.yaml

### DIFF
--- a/v2/en/requirements/database.mdx
+++ b/v2/en/requirements/database.mdx
@@ -19,7 +19,7 @@ The easiest and fastest way to set up a database for Evolution API v2 is through
 
 To set up PostgreSQL via Docker, follow these steps:
 
-1. Download the `docker-compose.yaml` file for PostgreSQL available [here](https://github.com/EvolutionAPI/evolution-api/blob/v2.0.0/Docker/postgres/docker-compose.yaml).
+1. Download the `docker-compose.yaml` file for PostgreSQL available [here](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/postgres/docker-compose.yaml).
 2. Navigate to the directory where the file was downloaded and run the command:
 
 ```bash
@@ -32,7 +32,7 @@ docker-compose up -d
 
 To set up MySQL via Docker, follow these steps:
 
-1. Download the `docker-compose.yaml` file for MySQL available [here](https://github.com/EvolutionAPI/evolution-api/blob/v2.0.0/Docker/mysql/docker-compose.yaml).
+1. Download the `docker-compose.yaml` file for MySQL available [here](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/mysql/docker-compose.yaml).
 2. Navigate to the directory where the file was downloaded and run the command:
 
 ```bash
@@ -40,6 +40,79 @@ docker-compose up -d
 ```
 
 3. The MySQL instance will be available at `localhost` on port `3306`.
+
+### Using Docker (Single file)
+
+If you don't want to have separate containers, you can create a single file with the database and the Evolution API. Follow the steps below:
+
+#### PostgreSQL
+
+1. Download the `docker-compose.yaml` file for PostgreSQL available [here](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/postgres/docker-compose.yaml).
+2. Open the file and add your Evolution API configuration specifying the `networks`. For example:
+```yaml
+services:
+  # Your Evolution API configuration:
+  evolution-api:
+    ...
+    networks:
+      - evolution-net
+    ...
+
+  # PostgreSQL configuration you downloaded:
+  postgres:
+    ...
+
+  pgadmin:
+    ...
+
+volumes:
+  postgres_data:
+  pgadmin_data:
+  evolution_instances:
+
+networks:
+  evolution-net:
+    name: evolution-net
+    driver: bridge
+```
+
+3. Save the file and run the command:
+```bash
+docker-compose up -d
+```
+
+#### MySQL
+
+1. Download the `docker-compose.yaml` file for MySQL available [here](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/mysql/docker-compose.yaml). 
+2. Open the file and add your Evolution API configuration specifying `networks`. For example:
+
+```yaml
+services:
+  # Sua configuração do Evolution API:
+  evolution-api:
+    ...
+    networks:
+      - evolution-net
+    ...
+
+  # Configuração do MySQL que você baixou:
+  mysql:
+    ...
+
+volumes:
+  mysql_data:
+  evolution_instances:
+
+networks:
+  evolution-net:
+    name: evolution-net
+    driver: bridge
+```
+
+3. Save the file and run the command:
+```bash
+docker-compose up -d
+```
 
 ### Environment Variables Configuration
 
@@ -66,6 +139,20 @@ DATABASE_SAVE_DATA_CONTACTS=true
 DATABASE_SAVE_DATA_CHATS=true
 DATABASE_SAVE_DATA_LABELS=true
 DATABASE_SAVE_DATA_HISTORIC=true
+```
+
+If you use a single [docker-compose.yaml](#using-docker-single-file), you should replace `localhost` with the name of your database service. For example:
+
+#### PostgreSQL
+```env
+# Database connection URI
+DATABASE_CONNECTION_URI='postgresql://user:password@postgres:5432/evolution?schema=public'
+```
+
+#### MySQL
+```env
+# Database connection URI
+DATABASE_CONNECTION_URI='postgresql://user:password@mysql:5432/evolution?schema=public'
 ```
 
 ### Local Installation

--- a/v2/en/requirements/redis.mdx
+++ b/v2/en/requirements/redis.mdx
@@ -15,7 +15,7 @@ The easiest and fastest way to set up Redis for Evolution API v2 is through Dock
 
 To set up Redis via Docker, follow these steps:
 
-1. Download the `docker-compose.yaml` file for Redis available [here](https://github.com/EvolutionAPI/evolution-api/blob/v2.0.0/Docker/redis/docker-compose.yaml).
+1. Download the `docker-compose.yaml` file for Redis available [here](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/redis/docker-compose.yaml).
 2. Navigate to the directory where the file was downloaded and run the command:
 
 ```bash
@@ -23,6 +23,41 @@ docker-compose up -d
 ```
 
 3. The Redis instance will be available at `localhost` on port `6379`.
+
+### Using Docker (Single File)
+
+If you don't want to have separate containers, you can create a single file with Redis and Evolution API. Follow the steps below:
+
+1. Download the `docker-compose.yaml` file for Redis available [here](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/redis/docker-compose.yaml).
+2. Open the file and add your Evolution API configuration specifying the `networks`. For example:
+
+```yaml
+services:
+  # Your Evolution API configuration:
+  evolution-api:
+    ...
+    networks:
+      - evolution-net
+    ...
+
+  # Redis configuration you downloaded:
+  redis:
+    ...
+
+volumes:
+  evolution_redis:
+  evolution_instances:
+
+networks:
+  evolution-net:
+    name: evolution-net
+    driver: bridge
+```
+
+3. Save the file and run the command:
+```bash
+docker-compose up -d
+```
 
 ### Environment Variables Configuration
 
@@ -43,6 +78,12 @@ CACHE_REDIS_SAVE_INSTANCES=false
 
 # Enable local cache
 CACHE_LOCAL_ENABLED=false
+```
+
+If you use a single [docker-compose.yaml](#using-docker-single-file), you should replace `localhost` with `redis`. For example:
+```env
+# Redis connection URI
+CACHE_REDIS_URI=redis://redis:6379/6
 ```
 
 ### Local Installation

--- a/v2/pt/requirements/database.mdx
+++ b/v2/pt/requirements/database.mdx
@@ -19,7 +19,7 @@ A maneira mais fácil e rápida de configurar um banco de dados para a Evolution
 
 Para configurar o PostgreSQL via Docker, siga os passos abaixo:
 
-1. Baixe o arquivo `docker-compose.yaml` para o PostgreSQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/main/Docker/postgres/docker-compose.yaml).
+1. Baixe o arquivo `docker-compose.yaml` para o PostgreSQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/postgres/docker-compose.yaml).
 2. Navegue até o diretório onde o arquivo foi baixado e execute o comando:
 
 ```bash
@@ -32,7 +32,7 @@ docker-compose up -d
 
 Para configurar o MySQL via Docker, siga os passos abaixo:
 
-1. Baixe o arquivo `docker-compose.yaml` para o MySQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/v2.0.0/Docker/mysql/docker-compose.yaml).
+1. Baixe o arquivo `docker-compose.yaml` para o MySQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/mysql/docker-compose.yaml).
 2. Navegue até o diretório onde o arquivo foi baixado e execute o comando:
 
 ```bash
@@ -40,6 +40,79 @@ docker-compose up -d
 ```
 
 3. A instância do MySQL estará disponível no endereço `localhost` na porta `3306`.
+
+### Utilizando Docker (Único arquivo)
+
+Caso não queira ter containers separados, você pode criar um único arquivo com o banco de dados e o Evolution API. Siga os passos abaixo:
+
+#### PostgreSQL
+
+1. Baixe o arquivo `docker-compose.yaml` para o PostgreSQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/postgres/docker-compose.yaml).
+2. Abra o arquivo e acrescente sua configuração do Evolution API especificando o `networks`. Por exemplo:
+
+```yaml
+services:
+  # Sua configuração do Evolution API:
+  evolution-api:
+    ...
+    networks:
+      - evolution-net
+    ...
+
+  # Configuração do PostgreSQL que você baixou:
+  postgres:
+    ...
+
+  pgadmin:
+    ...
+
+volumes:
+  postgres_data:
+  pgadmin_data:
+  evolution_instances:
+
+networks:
+  evolution-net:
+    name: evolution-net
+    driver: bridge
+```
+3. Salve o arquivo e execute o comando:
+```bash
+docker-compose up -d
+```
+
+#### MySQL
+
+1. Baixe o arquivo `docker-compose.yaml` para o MySQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/mysql/docker-compose.yaml).
+2. Abra o arquivo e acrescente sua configuração do Evolution API especificando o `networks`. Por exemplo:
+
+```yaml
+services:
+  # Sua configuração do Evolution API:
+  evolution-api:
+    ...
+    networks:
+      - evolution-net
+    ...
+
+  # Configuração do MySQL que você baixou:
+  mysql:
+    ...
+
+volumes:
+  mysql_data:
+  evolution_instances:
+
+networks:
+  evolution-net:
+    name: evolution-net
+    driver: bridge
+```
+
+3. Salve o arquivo e execute o comando:
+```bash
+docker-compose up -d
+```
 
 ### Configuração das Variáveis de Ambiente
 
@@ -66,6 +139,19 @@ DATABASE_SAVE_DATA_CONTACTS=true
 DATABASE_SAVE_DATA_CHATS=true
 DATABASE_SAVE_DATA_LABELS=true
 DATABASE_SAVE_DATA_HISTORIC=true
+```
+Caso use um único [docker-compose.yaml](#utilizando-docker-único-arquivo), você deve substituir o `localhost` pelo nome do serviço do banco de dados. Por exemplo:
+
+#### PostgreSQL
+```env
+# URI de conexão com o banco de dados
+DATABASE_CONNECTION_URI='postgresql://user:password@postgres:5432/evolution?schema=public'
+```
+
+#### MySQL
+```env
+# URI de conexão com o banco de dados
+DATABASE_CONNECTION_URI='postgresql://user:password@mysql:5432/evolution?schema=public'
 ```
 
 ### Instalação Local

--- a/v2/pt/requirements/redis.mdx
+++ b/v2/pt/requirements/redis.mdx
@@ -15,7 +15,7 @@ A maneira mais fácil e rápida de configurar o Redis para a Evolution API v2 é
 
 Para configurar o Redis via Docker, siga os passos abaixo:
 
-1. Baixe o arquivo `docker-compose.yaml` para o Redis disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/v2.0.0/Docker/redis/docker-compose.yaml).
+1. Baixe o arquivo `docker-compose.yaml` para o Redis disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/redis/docker-compose.yaml).
 2. Navegue até o diretório onde o arquivo foi baixado e execute o comando:
 
 ```bash
@@ -23,6 +23,41 @@ docker-compose up -d
 ```
 
 3. A instância do Redis estará disponível no endereço `localhost` na porta `6379`.
+
+
+### Utilizando Docker (Único arquivo)
+
+Caso não queira ter containers separados, você pode criar um único arquivo com o Redis e o Evolution API. Siga os passos abaixo:
+
+1. Baixe o arquivo `docker-compose.yaml` para o Redis disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/2.2.3/Docker/redis/docker-compose.yaml).
+2. Abra o arquivo e acrescente sua configuração do Evolution API especificando o `networks`. Por exemplo:
+
+```yaml
+services:
+  # Sua configuração do Evolution API:
+  evolution-api:
+    ...
+    networks:
+      - evolution-net
+    ...
+
+  # Configuração do Redis que você baixou:
+  redis:
+    ...
+
+volumes:
+  evolution_redis:
+  evolution_instances:
+
+networks:
+  evolution-net:
+    name: evolution-net
+    driver: bridge
+```
+3. Salve o arquivo e execute o comando:
+```bash
+docker-compose up -d
+```
 
 ### Configuração das Variáveis de Ambiente
 
@@ -43,6 +78,12 @@ CACHE_REDIS_SAVE_INSTANCES=false
 
 # Habilitar o cache local
 CACHE_LOCAL_ENABLED=false
+```
+
+Caso use um único [docker-compose.yaml](#utilizando-docker-único-arquivo), você deve substituir o `localhost` por `redis`. Por exemplo:
+```env
+# URI de conexão com o Redis
+CACHE_REDIS_URI=redis://redis:6379/6
 ```
 
 ### Instalação Local


### PR DESCRIPTION
Adds a section to the Database and Redis pages to configure a single `docker-compose.yaml` file:
- Portuguese and English
- Fixes links from version *v2.0.0* to *2.2.3*
- Configuration of `docker-compose.yaml` and Environment Variables

Reference Issue: https://github.com/EvolutionAPI/evolution-api/issues/1087#issuecomment-2576175586