### PR TITLE
fix: solved openapi-v2 validation warnings

### DIFF
--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -3505,7 +3505,7 @@
     },
     "/message/sendButtons/{instance}": {
       "post": {
-        "operationId": "sendList",
+        "operationId": "sendButtons",
         "summary": "Send Buttons",
         "tags": [
           "Message Controller"

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -1536,10 +1536,10 @@
     },
     "/settings/find/{instance}": {
       "get": {
-        "operationId": "findWebhook",
-        "summary": "Find Webhook",
+        "operationId": "findSettings",
+        "summary": "Find Settings",
         "tags": [
-          "Webhook Controller"
+          "Settings Controller"
         ],
         "deprecated": false,
         "security": [
@@ -1558,7 +1558,7 @@
             }
           }
         ],
-        "description": "Fetch Webhook configuration",
+        "description": "Fetch Settings configuration",
         "responses": {
           "200": {
             "description": "Ok",

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -6535,7 +6535,7 @@
     },
     "/typebot/changeStatus/{instance}": {
       "post": {
-        "operationId": "startTypebot",
+        "operationId": "changeStatusTypebot",
         "summary": "Change Session Status",
         "tags": [
           "Typebot Controller"

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -10594,7 +10594,7 @@
     },
     "/flowise/find/{instance}": {
       "get": {
-        "operationId": "fetchFlowiseBotSessions",
+        "operationId": "fetchFlowiseBotsSessions",
         "summary": "Recupera as sessões ativas do bot Flowise",
         "tags": [
           "Dify Controller"

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -6958,8 +6958,8 @@
     },
     "/typebot/delete/:typebotId/{instance}": {
       "delete": {
-        "operationId": "changeTypebotStatus",
-        "summary": "Delete Status",
+        "operationId": "deleteTypebotStatus",
+        "summary": "Delete typebot status",
         "tags": [
           "Typebot Controller"
         ],
@@ -6989,7 +6989,7 @@
             }
           }
         ],
-        "description": "Delete typebot",
+        "description": "Delete typebot status",
         "responses": {
           "200": {
             "description": "Ok",

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -5559,8 +5559,8 @@
     },
     "/group/acceptInviteCode/{instance}": {
       "get": {
-        "operationId": "fetchInviteCode",
-        "summary": "Fetch Group Invite Code",
+        "operationId": "acceptInviteCode",
+        "summary": "Accept Group Invite Code",
         "tags": [
           "Group Controller"
         ],

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -10886,7 +10886,7 @@
     },
     "/flowise/delete/:flowiseId/{instance}": {
       "delete": {
-        "operationId": "deleteBot",
+        "operationId": "deleteFlowiseBot",
         "summary": "Delete Bot Flowise",
         "tags": [
           "Group Controller"

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -6587,8 +6587,8 @@
     },
     "/typebot/settings/{instance}": {
       "post": {
-        "operationId": "startTypebot",
-        "summary": "Change Session Status",
+        "operationId": "settingsTypebot",
+        "summary": "Set settings typebot",
         "tags": [
           "Typebot Controller"
         ],

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -11627,7 +11627,7 @@
     },
     "/evolutionBot/delete/:evolutionBotId/{instance}": {
       "delete": {
-        "operationId": "deleteBot",
+        "operationId": "deleteEvoBot",
         "summary": "Delete Bot Evolution",
         "tags": [
           "Group Controller"

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -11583,12 +11583,12 @@
     },
     "/evolutionBot/find/{instance}": {
       "get": {
-        "operationId": "findEvo",
+        "operationId": "findEvoBots",
         "summary": "Find Bots Evo",
         "tags": [
           "OpenAI Controller"
         ],
-        "description": "Update evo bots.",
+        "description": "Find evo bots.",
         "security": [
           {
             "ApiKeyAuth": []

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -6749,8 +6749,8 @@
     },
     "/typebot/fetch/:typebotId/{instance}": {
       "get": {
-        "operationId": "findTypebot",
-        "summary": "Find Typebot",
+        "operationId": "fetchTypebot",
+        "summary": "Fetch Typebot",
         "tags": [
           "Typebot Controller"
         ],
@@ -6780,7 +6780,7 @@
             }
           }
         ],
-        "description": "Find typebot",
+        "description": "Fetch typebot",
         "responses": {
           "200": {
             "description": "Ok",

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -11897,17 +11897,6 @@
         "operationId": "getEvoInfo",
         "summary": "Get information about your EvolutionAPI",
         "deprecated": false,
-        "parameters": [
-          {
-            "name": "instance",
-            "in": "path",
-            "required": true,
-            "description": "ID of the instance to connect",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "description": "Get information about your EvolutionAPI",
         "responses": {
           "200": {
@@ -11945,8 +11934,7 @@
                   "example": {
                     "status": 200,
                     "message": "Welcome to the Evolution API, it is working!",
-                    "version": "1.7.4",
-                    "swagger": "http://example.evolution-api.com/docs",
+                    "version": "2.2.3",
                     "manager": "http://example.evolution-api.com/manager",
                     "documentation": "https://doc.evolution-api.com"
                   }

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -11392,7 +11392,7 @@
         "tags": [
           "OpenAI Controller"
         ],
-        "description": "Update evo bot.",
+        "description": "Find evo bot.",
         "security": [
           {
             "ApiKeyAuth": []

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -7694,7 +7694,7 @@
     },
     "/openai/find/{instance}": {
       "get": {
-        "operationId": "findBotOpenAI",
+        "operationId": "findBotsOpenAI",
         "summary": "Find OpenAI Bots",
         "tags": [
           "OpenIA Controller"

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -11800,7 +11800,7 @@
     },
     "/evolutionBot/fetchSessions/:evolutionBotId/{instance}": {
       "get": {
-        "operationId": "findEvolutionBot",
+        "operationId": "findEvolutionBotSession",
         "summary": "Find EvoBot session",
         "tags": [
           "Evolution Bot Controller"
@@ -11831,7 +11831,7 @@
             }
           }
         ],
-        "description": "Find evolution bot settings",
+        "description": "Find evolution bot session",
         "responses": {
           "200": {
             "description": "Ok",

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -6683,8 +6683,8 @@
     },
     "/typebot/fetchSettings/{instance}": {
       "get": {
-        "operationId": "findTypebot",
-        "summary": "Find Typebot",
+        "operationId": "findSettingsTypebot",
+        "summary": "Find Typebot settings",
         "tags": [
           "Typebot Controller"
         ],

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -4883,8 +4883,8 @@
     },
     "/chat/fetchProfile/{instance}": {
       "post": {
-        "operationId": "fetchBusinessProfile",
-        "summary": "Fetch Business Profile",
+        "operationId": "fetchProfile",
+        "summary": "Fetch Profile",
         "tags": [
           "Chat Controller"
         ],

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -11789,7 +11789,7 @@
             }
           }
         ],
-        "description": "Find evolution bot settings",
+        "description": "Find evolution bot session",
         "responses": {
           "200": {
             "description": "Ok",

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -5601,8 +5601,8 @@
     },
     "/group/revokeInviteCode/{instance}": {
       "post": {
-        "operationId": "fetchInviteCode",
-        "summary": "Fetch Group Invite Code",
+        "operationId": "revokeInviteCode",
+        "summary": "Revoke Group Invite Code",
         "tags": [
           "Group Controller"
         ],

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -6791,8 +6791,8 @@
     },
     "/typebot/fetchSessions/:typebotId/{instance}": {
       "get": {
-        "operationId": "findTypebot",
-        "summary": "Find session typebot",
+        "operationId": "fetchTypebotSession",
+        "summary": "Fetch session typebot",
         "tags": [
           "Typebot Controller"
         ],
@@ -6822,7 +6822,7 @@
             }
           }
         ],
-        "description": "Find session typebot",
+        "description": "Fetch session typebot",
         "responses": {
           "200": {
             "description": "Ok",

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -6747,7 +6747,7 @@
         }
       }
     },
-    "/typebot/fetch/:typebotId/{instance}": {
+    "/typebot/fetch/{typebotId}/{instance}": {
       "get": {
         "operationId": "fetchTypebot",
         "summary": "Fetch Typebot",
@@ -6789,7 +6789,7 @@
         }
       }
     },
-    "/typebot/fetchSessions/:typebotId/{instance}": {
+    "/typebot/fetchSessions/{typebotId}/{instance}": {
       "get": {
         "operationId": "fetchTypebotSession",
         "summary": "Fetch session typebot",
@@ -6831,7 +6831,7 @@
         }
       }
     },
-    "/typebot/update/:typebotId/{instance}": {
+    "/typebot/update/{typebotId}/{instance}": {
       "post": {
         "operationId": "changeTypebotStatus",
         "summary": "Change Typebot Status",
@@ -6956,7 +6956,7 @@
         }
       }
     },
-    "/typebot/delete/:typebotId/{instance}": {
+    "/typebot/delete/{typebotId}/{instance}": {
       "delete": {
         "operationId": "deleteTypebotStatus",
         "summary": "Delete typebot status",
@@ -7725,7 +7725,7 @@
         }
       }
     },
-    "/openai/find/:openaiBotId/{instance}": {
+    "/openai/find/{openaiBotId}/{instance}": {
       "get": {
         "operationId": "findBotOpenAI",
         "summary": "Find OpenAI Bot",
@@ -7767,7 +7767,7 @@
         }
       }
     },
-    "/openai/delete/:openaiBotId/{instance}": {
+    "/openai/delete/{openaiBotId}/{instance}": {
       "delete": {
         "operationId": "deleteBotOpenAI",
         "summary": "Delete OpenAI Bot",
@@ -7809,7 +7809,7 @@
         }
       }
     },
-    "/openai/update/:openaiBotId/{instance}": {
+    "/openai/update/{openaiBotId}/{instance}": {
       "put": {
         "operationId": "updateBotOpenAI",
         "summary": "Update OpenAI Bot",
@@ -8075,7 +8075,7 @@
         }
       }
     },
-    "/openai/creds/:openaiCredsId/{instance}": {
+    "/openai/creds/{openaiCredsId}/{instance}": {
       "delete": {
         "operationId": "deleteCredsOpenAI",
         "summary": "Delete OpenAI Creds",
@@ -8361,7 +8361,7 @@
         }
       }
     },
-    "/openai/fetchSessions/:openaiBotId/{instance}": {
+    "/openai/fetchSessions/{openaiBotId}/{instance}": {
       "get": {
         "operationId": "fetchSessions",
         "summary": "Fetch sessions of the OpenAI bot instance",
@@ -8608,7 +8608,7 @@
         }
       }
     },
-    "/dify/find/:difyId/{instance}": {
+    "/dify/find/{difyId}/{instance}": {
       "get": {
         "operationId": "findDify",
         "summary": "Find Bot Dify",
@@ -8661,7 +8661,7 @@
         }
       }
     },
-    "/dify/update/:difyId/{instance}": {
+    "/dify/update/{difyId}/{instance}": {
       "put": {
         "operationId": "updateDifyBot",
         "summary": "Create a new Dify bot instance",
@@ -9044,7 +9044,7 @@
         }
       }
     },
-    "/dify/fetchSessions/:difyId/{instance}": {
+    "/dify/fetchSessions/{difyId}/{instance}": {
       "get": {
         "operationId": "fetchDifyBotSessions",
         "summary": "Recupera as sessões ativas do bot Dify",
@@ -9273,7 +9273,7 @@
         }
       }
     },
-    "/n8n/find/:n8nId/{instance}": {
+    "/n8n/find/{n8nId}/{instance}": {
       "get": {
         "operationId": "findN8n",
         "summary": "Find n8n Bot",
@@ -9326,7 +9326,7 @@
         }
       }
     },
-    "/n8n/update/:n8nId/{instance}": {
+    "/n8n/update/{n8nId}/{instance}": {
       "put": {
         "operationId": "updateN8nBot",
         "summary": "Create a new n8n bot instance",
@@ -9701,7 +9701,7 @@
         }
       }
     },
-    "/n8n/fetchSessions/:n8nId/{instance}": {
+    "/n8n/fetchSessions/{n8nId}/{instance}": {
       "get": {
         "operationId": "fetchN8nBotSessions",
         "summary": "Recupera as sessões ativas do bot n8n",
@@ -9927,7 +9927,7 @@
         }
       }
     },
-    "/evoai/find/:evoaiId/{instance}": {
+    "/evoai/find/{evoaiId}/{instance}": {
       "get": {
         "operationId": "findEvoAIBot",
         "summary": "Find EvoAI Bot",
@@ -9980,7 +9980,7 @@
         }
       }
     },
-    "/evoai/update/:evoaiId/{instance}": {
+    "/evoai/update/{evoaiId}/{instance}": {
       "put": {
         "operationId": "updateEvoAIBot",
         "summary": "Create a new EvoAI bot instance",
@@ -10352,7 +10352,7 @@
         }
       }
     },
-    "/evoai/fetchSessions/:evoaiId/{instance}": {
+    "/evoai/fetchSessions/{evoaiId}/{instance}": {
       "get": {
         "operationId": "fetchEvoAIBotSessions",
         "summary": "Recupera as sessões ativas do bot EvoAI",
@@ -10635,7 +10635,7 @@
         }
       }
     },
-    "/flowise/find/:flowiseId/{instance}": {
+    "/flowise/find/{flowiseId}/{instance}": {
       "get": {
         "operationId": "fetchFlowiseBotSessions",
         "summary": "Recupera as sessões ativas do bot Flowise",
@@ -10687,7 +10687,7 @@
         }
       }
     },
-    "/flowise/update/:flowiseId/{instance}": {
+    "/flowise/update/{flowiseId}/{instance}": {
       "post": {
         "operationId": "updateFlowiseInstance",
         "summary": "Atualiza uma instância do Flowise",
@@ -10884,7 +10884,7 @@
         }
       }
     },
-    "/flowise/delete/:flowiseId/{instance}": {
+    "/flowise/delete/{flowiseId}/{instance}": {
       "delete": {
         "operationId": "deleteFlowiseBot",
         "summary": "Delete Bot Flowise",
@@ -10909,7 +10909,7 @@
           },
           {
             "name": "flowiseId",
-            "in": "query",
+            "in": "path",
             "required": true,
             "description": "Id Bot Flowise",
             "schema": {
@@ -11048,7 +11048,7 @@
         }
       }
     },
-    "/flowise/fetchSessions/:flowiseId/{instance}": {
+    "/flowise/fetchSessions/{flowiseId}/{instance}": {
       "get": {
         "operationId": "fetchFlowiseSessions",
         "summary": "Recupera as sessões ativas do bot Flowise",
@@ -11385,7 +11385,7 @@
         }
       }
     },
-    "/evolutionBot/fetch/:evolutionBotId/{instance}": {
+    "/evolutionBot/fetch/{evolutionBotId}/{instance}": {
       "get": {
         "operationId": "findEvo",
         "summary": "Find Bot Evo",
@@ -11438,7 +11438,7 @@
         }
       }
     },
-    "/evolutionBot/update/:evolutionBotId/{instance}": {
+    "/evolutionBot/update/{evolutionBotId}/{instance}": {
       "put": {
         "operationId": "updateEvolutionBot",
         "summary": "Update Evolution Bot",
@@ -11625,7 +11625,7 @@
         }
       }
     },
-    "/evolutionBot/delete/:evolutionBotId/{instance}": {
+    "/evolutionBot/delete/{evolutionBotId}/{instance}": {
       "delete": {
         "operationId": "deleteEvoBot",
         "summary": "Delete Bot Evolution",
@@ -11650,7 +11650,7 @@
           },
           {
             "name": "evolutionBotId",
-            "in": "query",
+            "in": "path",
             "required": true,
             "description": "Id Bot Evolution",
             "schema": {
@@ -11798,7 +11798,7 @@
         }
       }
     },
-    "/evolutionBot/fetchSessions/:evolutionBotId/{instance}": {
+    "/evolutionBot/fetchSessions/{evolutionBotId}/{instance}": {
       "get": {
         "operationId": "findEvolutionBotSession",
         "summary": "Find EvoBot session",

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -3913,7 +3913,7 @@
     },
     "/chat/markChatUnread/{instance}": {
       "post": {
-        "operationId": "markMessageAsRead",
+        "operationId": "markMessageAsUnread",
         "summary": "Mark Message As Unread",
         "tags": [
           "Chat Controller"


### PR DESCRIPTION

The current `openapi-v2` specification has some semantic errors. This PR fixed all of hem except one.

The only error not solve here due to it's nature is:
> Semantic error at paths./chat/deleteMessageForEveryone/{instance}.delete.requestBody
> DELETE operations cannot have a requestBody.

<details>
<summary>Click here to view all errors.</summary>
> Semantic error at paths./settings/find/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./message/sendButtons/{instance}.post.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./chat/markChatUnread/{instance}.post.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./chat/deleteMessageForEveryone/{instance}.delete.requestBody
> DELETE operations cannot have a requestBody.
 
> Semantic error at paths./chat/fetchProfile/{instance}.post.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./group/acceptInviteCode/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./group/revokeInviteCode/{instance}.post.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./typebot/changeStatus/{instance}.post.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./typebot/settings/{instance}.post.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./typebot/find/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./typebot/fetch/:typebotId/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./typebot/fetch/:typebotId/{instance}.get.parameters.1.name
> Path parameter "typebotId" must have the corresponding {typebotId} segment in the "/typebot/fetch/:typebotId/{instance}" path
 
> Semantic error at paths./typebot/fetchSessions/:typebotId/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./typebot/fetchSessions/:typebotId/{instance}.get.parameters.1.name
> Path parameter "typebotId" must have the corresponding {typebotId} segment in the "/typebot/fetchSessions/:typebotId/{instance}" path
 
> Semantic error at paths./typebot/update/:typebotId/{instance}.post.parameters.1.name
> Path parameter "typebotId" must have the corresponding {typebotId} segment in the "/typebot/update/:typebotId/{instance}" path
 
> Semantic error at paths./typebot/delete/:typebotId/{instance}.delete.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./typebot/delete/:typebotId/{instance}.delete.parameters.1.name
> Path parameter "typebotId" must have the corresponding {typebotId} segment in the "/typebot/delete/:typebotId/{instance}" path
 
> Semantic error at paths./openai/find/:openaiBotId/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./openai/find/:openaiBotId/{instance}.get.parameters.1.name
> Path parameter "openaiBotId" must have the corresponding {openaiBotId} segment in the "/openai/find/:openaiBotId/{instance}" path
 
> Semantic error at paths./openai/delete/:openaiBotId/{instance}.delete.parameters.1.name
> Path parameter "openaiBotId" must have the corresponding {openaiBotId} segment in the "/openai/delete/:openaiBotId/{instance}" path
 
> Semantic error at paths./openai/update/:openaiBotId/{instance}.put.parameters.1.name
> Path parameter "openaiBotId" must have the corresponding {openaiBotId} segment in the "/openai/update/:openaiBotId/{instance}" path
 
> Semantic error at paths./openai/creds/:openaiCredsId/{instance}.delete.parameters.1.name
> Path parameter "openaiCredsId" must have the corresponding {openaiCredsId} segment in the "/openai/creds/:openaiCredsId/{instance}" path
 
> Semantic error at paths./openai/fetchSessions/:openaiBotId/{instance}.get.parameters.0.name
> Path parameter "openaiBotId" must have the corresponding {openaiBotId} segment in the "/openai/fetchSessions/:openaiBotId/{instance}" path
 
> Semantic error at paths./dify/find/:difyId/{instance}.get.parameters.1.name
> Path parameter "difyId" must have the corresponding {difyId} segment in the "/dify/find/:difyId/{instance}" path
 
> Semantic error at paths./dify/update/:difyId/{instance}.put.parameters.1.name
> Path parameter "difyId" must have the corresponding {difyId} segment in the "/dify/update/:difyId/{instance}" path
 
> Semantic error at paths./dify/fetchSessions/:difyId/{instance}.get.parameters.0.name
> Path parameter "difyId" must have the corresponding {difyId} segment in the "/dify/fetchSessions/:difyId/{instance}" path
 
> Semantic error at paths./n8n/find/:n8nId/{instance}.get.parameters.1.name
> Path parameter "n8nId" must have the corresponding {n8nId} segment in the "/n8n/find/:n8nId/{instance}" path
 
> Semantic error at paths./n8n/update/:n8nId/{instance}.put.parameters.1.name
> Path parameter "n8nId" must have the corresponding {n8nId} segment in the "/n8n/update/:n8nId/{instance}" path
 
> Semantic error at paths./n8n/fetchSessions/:n8nId/{instance}.get.parameters.0.name
> Path parameter "n8nId" must have the corresponding {n8nId} segment in the "/n8n/fetchSessions/:n8nId/{instance}" path
 
> Semantic error at paths./evoai/find/:evoaiId/{instance}.get.parameters.1.name
> Path parameter "evoaiId" must have the corresponding {evoaiId} segment in the "/evoai/find/:evoaiId/{instance}" path
 
> Semantic error at paths./evoai/update/:evoaiId/{instance}.put.parameters.1.name
> Path parameter "evoaiId" must have the corresponding {evoaiId} segment in the "/evoai/update/:evoaiId/{instance}" path
 
> Semantic error at paths./evoai/fetchSessions/:evoaiId/{instance}.get.parameters.0.name
> Path parameter "evoaiId" must have the corresponding {evoaiId} segment in the "/evoai/fetchSessions/:evoaiId/{instance}" path
 
> Semantic error at paths./flowise/find/:flowiseId/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./flowise/find/:flowiseId/{instance}.get.parameters.1.name
> Path parameter "flowiseId" must have the corresponding {flowiseId} segment in the "/flowise/find/:flowiseId/{instance}" path
 
> Semantic error at paths./flowise/update/:flowiseId/{instance}.post.parameters.0.name
> Path parameter "flowiseId" must have the corresponding {flowiseId} segment in the "/flowise/update/:flowiseId/{instance}" path
 
> Semantic error at paths./flowise/fetchSessions/:flowiseId/{instance}.get.parameters.1.name
> Path parameter "flowiseId" must have the corresponding {flowiseId} segment in the "/flowise/fetchSessions/:flowiseId/{instance}" path
 
> Semantic error at paths./evolutionBot/fetch/:evolutionBotId/{instance}.get.parameters.1.name
> Path parameter "evolutionBotId" must have the corresponding {evolutionBotId} segment in the "/evolutionBot/fetch/:evolutionBotId/{instance}" path
 
> Semantic error at paths./evolutionBot/update/:evolutionBotId/{instance}.put.parameters.0.name
> Path parameter "evolutionBotId" must have the corresponding {evolutionBotId} segment in the "/evolutionBot/update/:evolutionBotId/{instance}" path
 
> Semantic error at paths./evolutionBot/find/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./evolutionBot/delete/:evolutionBotId/{instance}.delete.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./evolutionBot/fetchSessions/:evolutionBotId/{instance}.get.operationId
> Operations must have unique operationIds.
 
> Semantic error at paths./evolutionBot/fetchSessions/:evolutionBotId/{instance}.get.parameters.1.name
> Path parameter "evolutionBotId" must have the corresponding {evolutionBotId} segment in the "/evolutionBot/fetchSessions/:evolutionBotId/{instance}" path
 
> Semantic error at paths./.get.parameters.0.name
> Path parameter "instance" must have the corresponding {instance} segment in the "/" path
</details>

I've created a commit for each fixed error for easier review.