### PR TITLE
docs: Update link to MySQL Docker Compose configuration

### DIFF
--- a/v2/pt/requirements/database.mdx
+++ b/v2/pt/requirements/database.mdx
@@ -32,7 +32,7 @@ docker-compose up -d
 
 Para configurar o MySQL via Docker, siga os passos abaixo:
 
-1. Baixe o arquivo `docker-compose.yaml` para o MySQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/v2.0.0/Docker/mysql/docker-compose.yaml).
+1. Baixe o arquivo `docker-compose.yaml` para o MySQL disponível [aqui](https://github.com/EvolutionAPI/evolution-api/blob/main/Docker/mysql/docker-compose.yaml).
 2. Navegue até o diretório onde o arquivo foi baixado e execute o comando:
 
 ```bash


### PR DESCRIPTION
The previous link to the MySQL Docker Compose setup in the database configuration guide was incorrect. This commit updates the URL to ensure it points to the correct resource.

## Summary by Sourcery

Documentation:
- Fix broken link to MySQL Docker Compose YAML in the pt/requirements database documentation.