### PR TITLE
typo: text

### DIFF
--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -1648,7 +1648,7 @@
                   },
                   "text": {
                     "type": "string",
-                    "description": "Test message to send"
+                    "description": "Text message to send"
                   },
                   "delay": {
                     "type": "integer",


### PR DESCRIPTION
The `text` field in `sendText` endpoint has a typo in its description.

## Summary by Sourcery

Documentation:
- Correct typo in the `text` field description of the sendText endpoint in the OpenAPI v2 specification